### PR TITLE
Compact output

### DIFF
--- a/imgsorter/imgsorter.toml
+++ b/imgsorter/imgsorter.toml
@@ -31,13 +31,20 @@ target_dir = 'D:\Temp\New folder test remove - Copy'
 min_files_per_dir = 1
 
 # When sorting a large number of files, set this property to a number
-# higher than zero to print a more compact output during dry runs.
-# This is done by omitting the output of consecutive files in the same folder
-# with the same status which exceed this exceeding this number, instead of
-# simply listing all files with identical statuses. For example:
-# " └── (omitted output for files with same status ..... (5x) file will be copied)"
-# If this option is missing or set to 0, no compacting will occur
-min_files_before_compacting_output = 1
+#  higher than zero to print a more compact output during dry runs.
+# This is done by truncating the output of consecutive files in the same folder
+#  with the same status which exceed this exceeding this number.
+# Example output if this is disabled:
+#   ├── IMG-20190128.jpg <--- D:\Pics\IMG-20190128.jpg ........... target file exists, will be skipped
+#   ├── IMG-20190128.jpg <--- D:\Pics\Sort me\IMG-20190128.jpg ... target file exists, will be skipped
+#   ├── IMG-20190128.jpg <--- D:\Pics\More\IMG-20190128.jpg ...... target file exists, will be skipped
+#   └── IMG-20190129.jpg <--- D:\Pics\IMG-20190129.jpg ........... file will be copied
+# Example output if this is enabled:
+#   ├── IMG-20190128.jpg <--- D:\Pics\IMG-20190128.jpg ... target file exists, will be skipped
+#   ·-- (snipped output for 2 files with same status)
+#   └── IMG-20190129.jpg <--- D:\Pics\IMG-20190129.jpg ... file will be copied
+# If this option is missing or set to 0, no truncating will occur
+min_files_before_compacting_output = 3
 
 # The name of the folder which will hold all files for any given date,
 #   which holds less than or equal the [min_files_per_dir] threshold.

--- a/imgsorter/imgsorter.toml
+++ b/imgsorter/imgsorter.toml
@@ -37,7 +37,7 @@ min_files_per_dir = 1
 # simply listing all files with identical statuses. For example:
 # " └── (omitted output for files with same status ..... (5x) file will be copied)"
 # If this option is missing or set to 0, no compacting will occur
-min_files_before_compacting_output = 0
+min_files_before_compacting_output = 1
 
 # The name of the folder which will hold all files for any given date,
 #   which holds less than or equal the [min_files_per_dir] threshold.

--- a/imgsorter/imgsorter.toml
+++ b/imgsorter/imgsorter.toml
@@ -30,6 +30,15 @@ target_dir = 'D:\Temp\New folder test remove - Copy'
 # If this option is missing, the default "1" will be used.
 min_files_per_dir = 1
 
+# When sorting a large number of files, set this property to a number
+# higher than zero to print a more compact output during dry runs.
+# This is done by snipping the output of consecutive files in the same folder
+# with the same status which exceed this exceeding this number, instead of
+# simply listing all files with identical statuses. For example:
+# " └── (snipped output for files with same status ..... (5x) file will be copied)"
+# If this option is missing or set to 0, no snipping will occur
+min_files_before_snipping_output = 3
+
 # The name of the folder which will hold all files for any given date,
 #   which holds less than or equal the [min_files_per_dir] threshold.
 # If this option is missing, the default 'Miscellaneous' will be used.

--- a/imgsorter/imgsorter.toml
+++ b/imgsorter/imgsorter.toml
@@ -32,12 +32,12 @@ min_files_per_dir = 1
 
 # When sorting a large number of files, set this property to a number
 # higher than zero to print a more compact output during dry runs.
-# This is done by snipping the output of consecutive files in the same folder
+# This is done by omitting the output of consecutive files in the same folder
 # with the same status which exceed this exceeding this number, instead of
 # simply listing all files with identical statuses. For example:
-# " └── (snipped output for files with same status ..... (5x) file will be copied)"
-# If this option is missing or set to 0, no snipping will occur
-min_files_before_snipping_output = 3
+# " └── (omitted output for files with same status ..... (5x) file will be copied)"
+# If this option is missing or set to 0, no compacting will occur
+min_files_before_compacting_output = 0
 
 # The name of the folder which will hold all files for any given date,
 #   which holds less than or equal the [min_files_per_dir] threshold.

--- a/imgsorter/src/config.rs
+++ b/imgsorter/src/config.rs
@@ -10,7 +10,7 @@ use toml::*;
 
 // Config defaults
 const DEFAULT_MIN_COUNT: i64 = 1;
-const DEFAULT_SNIPPING_COUNT: usize = 0;
+const DEFAULT_COMPACTING_MIN_COUNT: usize = 0;
 const DEFAULT_COPY: bool = true;
 const DEFAULT_SILENT: bool = false;
 const DEFAULT_DRY_RUN: bool = false;
@@ -52,7 +52,7 @@ pub struct Args {
 
     /// When doing a dry run, omit output for files with the same
     /// status if exceeding this threshold to save visual space
-    pub snipping_threshold: usize,
+    pub compacting_threshold: usize,
 
     /// The name of the subdir which will hold files for any given date
     /// with less than or equal to the [min_files_per_dir] threshold
@@ -111,7 +111,7 @@ impl Args {
                 target_dir: cwd.clone().join(DEFAULT_TARGET_SUBDIR),
                 source_recursive: DEFAULT_SOURCE_RECURSIVE,
                 min_files_per_dir: DEFAULT_MIN_COUNT,
-                snipping_threshold: DEFAULT_SNIPPING_COUNT,
+                compacting_threshold: DEFAULT_COMPACTING_MIN_COUNT,
                 oneoffs_dir_name: String::from(DEFAULT_ONEOFFS_DIR_NAME),
                 cwd,
                 silent: DEFAULT_SILENT,
@@ -345,8 +345,8 @@ impl Args {
                                                 args.min_files_per_dir = min_files_per_dir;
                                             }
 
-                                            if let Some(min_files_before_snipping_output) = get_positive_integer_value(&folders, "min_files_before_snipping_output", &mut missing_vals, &mut invalid_vals) {
-                                                args.snipping_threshold = min_files_before_snipping_output as usize;
+                                            if let Some(compacting_threshold) = get_positive_integer_value(&folders, "min_files_before_compacting_output", &mut missing_vals, &mut invalid_vals) {
+                                                args.compacting_threshold = compacting_threshold as usize;
                                             }
 
                                             if let Some(oneoffs_dir_name) = get_string_value(&folders, "target_oneoffs_subdir_name", &mut missing_vals) {
@@ -578,8 +578,8 @@ impl Args {
         self.source_dir.len() > 1
     }
 
-    pub fn is_status_snipping_disabled(&self) -> bool {
-        self.snipping_threshold <= 0
+    pub fn is_compacting_enabled(&self) -> bool {
+        self.compacting_threshold > 0
     }
 }
 

--- a/imgsorter/src/config.rs
+++ b/imgsorter/src/config.rs
@@ -10,6 +10,7 @@ use toml::*;
 
 // Config defaults
 const DEFAULT_MIN_COUNT: i64 = 1;
+const DEFAULT_SNIPPING_COUNT: usize = 0;
 const DEFAULT_COPY: bool = true;
 const DEFAULT_SILENT: bool = false;
 const DEFAULT_DRY_RUN: bool = false;
@@ -48,6 +49,10 @@ pub struct Args {
     /// The minimum number of files with the same date necessary
     /// for a dedicated subdir to be created
     pub min_files_per_dir: i64,
+
+    /// When doing a dry run, omit output for files with the same
+    /// status if exceeding this threshold to save visual space
+    pub snipping_threshold: usize,
 
     /// The name of the subdir which will hold files for any given date
     /// with less than or equal to the [min_files_per_dir] threshold
@@ -106,6 +111,7 @@ impl Args {
                 target_dir: cwd.clone().join(DEFAULT_TARGET_SUBDIR),
                 source_recursive: DEFAULT_SOURCE_RECURSIVE,
                 min_files_per_dir: DEFAULT_MIN_COUNT,
+                snipping_threshold: DEFAULT_SNIPPING_COUNT,
                 oneoffs_dir_name: String::from(DEFAULT_ONEOFFS_DIR_NAME),
                 cwd,
                 silent: DEFAULT_SILENT,
@@ -339,6 +345,10 @@ impl Args {
                                                 args.min_files_per_dir = min_files_per_dir;
                                             }
 
+                                            if let Some(min_files_before_snipping_output) = get_positive_integer_value(&folders, "min_files_before_snipping_output", &mut missing_vals, &mut invalid_vals) {
+                                                args.snipping_threshold = min_files_before_snipping_output as usize;
+                                            }
+
                                             if let Some(oneoffs_dir_name) = get_string_value(&folders, "target_oneoffs_subdir_name", &mut missing_vals) {
                                                 // get_string_value already filters out empty strings, but just to be safe
                                                 if !oneoffs_dir_name.is_empty() {
@@ -566,6 +576,10 @@ impl Args {
 
     pub fn has_multiple_sources(&self) -> bool {
         self.source_dir.len() > 1
+    }
+
+    pub fn is_status_snipping_disabled(&self) -> bool {
+        self.snipping_threshold <= 0
     }
 }
 

--- a/imgsorter/src/utils.rs
+++ b/imgsorter/src/utils.rs
@@ -350,13 +350,13 @@ impl Padder {
     /// Adds space padding to the maximum padding length for the snipping output.
     /// ```
     /// ├── IMG-20190128.jpg <--- D:\Pics\IMG-20190128.jpg ... target file exists, will be skipped
-    /// ·-- (omitted output for 2 files with same status)
+    /// ·-- (snipped output for 2 files with same status)
     /// └── IMG-20190129.jpg <--- D:\Pics\IMG-20190129.jpg ... file will be copied
     /// ```
     pub fn format_dryrun_snipped_output(&self, skip_count: usize, indent_level: usize, is_last_dir: bool, args: &Args) -> String {
 
         let snip_text = ColoredString::italic_dim(
-            format!("(omitted output for {} files with same status)", skip_count).as_str());
+            format!("(snipped output for {} files with same status)", skip_count).as_str());
 
         let indented_ommitted = indent_string_snipped(
             indent_level,

--- a/imgsorter/todos.yaml
+++ b/imgsorter/todos.yaml
@@ -116,6 +116,7 @@
     [ ] how to treat files without EXIF (e.g. images received over WhatsApp)
     [ ] after move, leave a txt file in place named "where are my photos" which explains where they were moved (process summary); have option to disable this
     [x] colored text
+    [ ] crate for colors and format - https://stackoverflow.com/questions/69981449/how-do-i-print-colored-text-to-the-terminal-in-rust
     [ ] more comments and examples for Padder methods + rearrange more logically
 
 [ ] 9 - Docs

--- a/imgsorter/todos.yaml
+++ b/imgsorter/todos.yaml
@@ -1,5 +1,4 @@
 [-] 'dirs created' stat - differentiate between "date dirs" and "device dirs"
-[ ] dry run - option to not print everything, truncate after e.g. 5 files in same folder with same status (but save everything to log)
 
 - implement Display for Args and print before confirmation
 - clippy
@@ -56,7 +55,7 @@
 [ ] 5 - Optimize code
     [x] a - struct to model "supported file" with required metadata (file name, device info, date, etc)
     [ ] b - separate module for "file utils"
-    [ ] c - logging (replace debug printouts plus check every match/Err and ?)
+    [ ] c - logging (replace debug printouts plus check every match/Err and ? plus add files omitted by compact mode)
     [ ] d - better error handling (e.g. check all `.unwrap()`s)
     [ ] e - better name for SupportedFile (or maybe don't accept Unknown file types)
     [ ] f - universal line terminators
@@ -101,7 +100,7 @@
     [x] colored separator arrows
     [ ] separator arrow color should match file copy status (needs rework of how statuses are returned and colored)
     [ ] increase padding spaces from 1 to 2
-    [ ] dry run - option to not print everything, truncate after e.g. 5 files in same folder with same status (but save everything to log)
+    [x] dry run - option to not print everything, truncate after e.g. 5 files in same folder with same status (but save everything to log)
     [x] prettier dir trees (show branches ending when reaching last entry)
     [ ] show dir tree when presenting the source paths before confirmation, instead of a simple list of paths
         - show full path only for the sources in config, not for the recursively found subdirs


### PR DESCRIPTION
During dry runs, truncate the output of consecutive files in the same folder with the same status which exceed a configured threshold